### PR TITLE
Remove extra parenthesis and reorganize variables

### DIFF
--- a/datasets/fishermen_mercury_README.txt
+++ b/datasets/fishermen_mercury_README.txt
@@ -10,9 +10,12 @@ group of non-fishermen.
 
 Variables/names
 
-Fisherman indicator  (fisherman)
-Weight in kg    (weight)
-Fish meals per week    ((fishmlwk)
-Parts of fish consumed: 0=none, 1=muscle tissue only, 2=mt and sometimes
-              whole fish, 3=whole fish  (fishpart)
-Total Mercury in mg/g     (total_mercury)
+Fisherman indicator     (fisherman)
+Weight in kg            (weight)
+Fish meals per week     (fishmlwk)
+Parts of fish consumed: (fishpart)
+    0=none,
+    1=muscle tissue only,
+    2=mt and sometimes whole fish,
+    3=whole fish
+Total Mercury in mg/g   (total_mercury)


### PR DESCRIPTION
I was going through the boot camp and noticed an extra paren in the README for the dataset. Also, I reorganized variable names to make it easier to read. Hope that's okay.